### PR TITLE
Separate event json

### DIFF
--- a/notification/function/lambda_function.py
+++ b/notification/function/lambda_function.py
@@ -18,7 +18,7 @@ from boto3 import client, session
 from botocore.exceptions import ClientError
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.ERROR)
 logger.handlers[0].setFormatter(
     logging.Formatter("[%(asctime)s][%(levelname)s] %(message)s")
 )

--- a/notification/function/lambda_function.py
+++ b/notification/function/lambda_function.py
@@ -18,7 +18,7 @@ from boto3 import client, session
 from botocore.exceptions import ClientError
 
 logger = logging.getLogger()
-logger.setLevel(logging.ERROR)
+logger.setLevel(logging.INFO)
 logger.handlers[0].setFormatter(
     logging.Formatter("[%(asctime)s][%(levelname)s] %(message)s")
 )
@@ -642,6 +642,10 @@ def lambda_handler(event, context):
     s3_version_id = pipeline_execution["pipelineExecution"]["artifactRevisions"][0][
         "revisionId"
     ]
+    source_bucket_object_key = (
+        source_bucket_object_key.rsplit("/", 1)[0] + "/events/%s" % s3_version_id
+    )
+
     logger.info(
         "Downloading source from s3://%s/%s with VersionId %s"
         % (source_bucket, source_bucket_object_key, s3_version_id)
@@ -649,16 +653,11 @@ def lambda_handler(event, context):
     s3.download_file(
         source_bucket,
         source_bucket_object_key,
-        "/tmp/code.zip",
-        ExtraArgs={"VersionId": s3_version_id},
+        "/tmp/event.json",
     )
 
-    logger.info("Unzipping top /tmp/code...")
-    code_zip = ZipFile("/tmp/code.zip", "r")
-    ZipFile.extractall(code_zip, "/tmp/code")
-
     # Open json file containing event data from when the source zip was created
-    f = open("/tmp/code/event.json", "r")
+    f = open("/tmp/event.json", "r")
     content = f.readline()
     request = json.loads(content)
 

--- a/notification/function/template.json
+++ b/notification/function/template.json
@@ -106,7 +106,7 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "lambda_function.lambda_handler",
-        "MemorySize": 192,
+        "MemorySize": 128,
         "Role": {
           "Fn::GetAtt": [
             "NotificationRole",


### PR DESCRIPTION
Implements support for event.json not in zip folder, from [https://github.com/beardnecks/aws-git-integration/pull/3](https://github.com/beardnecks/aws-git-integration/pull/3). Speeds up the function, providing quicker notifications, requires less ram, and reducing costs per 1k runs 300%